### PR TITLE
Adding patching mechanisms to the data store

### DIFF
--- a/greyscale_record.gemspec
+++ b/greyscale_record.gemspec
@@ -1,4 +1,4 @@
-# coding: utf-8
+  # coding: utf-8
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'greyscale_record/version'
@@ -30,5 +30,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "minitest", "~> 5.0"
   spec.add_development_dependency "simplecov"
   spec.add_development_dependency "m"
-
+  spec.add_development_dependency "hana"
 end

--- a/lib/greyscale_record.rb
+++ b/lib/greyscale_record.rb
@@ -5,6 +5,8 @@ require 'active_support'
 require 'active_support/concern'
 require 'active_support/core_ext/class/attribute'
 require 'active_support/core_ext/hash'
+require 'active_support/core_ext/hash/keys'
+require 'active_support/core_ext/object/deep_dup'
 require 'yaml'
 
 module GreyscaleRecord

--- a/lib/greyscale_record/data_store/engine.rb
+++ b/lib/greyscale_record/data_store/engine.rb
@@ -25,8 +25,7 @@ module GreyscaleRecord
       #
       # Yeah. OK.
 
-      attr_reader :store
-      delegate :apply_patch, :remove_patch, :with_patch, to: :store 
+      delegate :apply_patch, :remove_patch, :with_patch, :table, to: :store 
 
       def initialize( driver )
         @driver = driver
@@ -36,7 +35,7 @@ module GreyscaleRecord
       # Read only store. No writes allowed. 
 
       def find( options = {} )
-        table = store[options.delete(:_table)]
+        table = store.table( options.delete(:_table) )
         if GreyscaleRecord.live_reload
           load_table!( table )
         end
@@ -45,16 +44,12 @@ module GreyscaleRecord
         table.find options
       end
 
-      def table( name )
-        store[name]
-      end
-
       def add_table( name )
         load_table! name
       end
 
-      def add_index( table_name, column_name )
-        store[table_name].add_index( column_name )
+      def add_index( name, column )
+        store.table( name ).add_index( column )
       end
 
       private
@@ -64,7 +59,7 @@ module GreyscaleRecord
       end
 
       def load_table!( name )
-        store[name] = @driver.load!( name )
+        store.init_table name, @driver.load!( name )
       end
     end
   end

--- a/test/engine_test.rb
+++ b/test/engine_test.rb
@@ -1,0 +1,56 @@
+require 'test_helper'
+require 'hana'
+
+class EngineTest < Minitest::Test
+  def setup
+    @patch = ::Hana::Patch.new [ { 'op' => 'add', 'path' => '/people/mike', 'value' => { id: "mike", name: "Mike Uchman", url_slug: "mike-uchman", title: "chief balling officer" } } ]
+  end
+
+  def test_can_apply_patch
+    GreyscaleRecord::Base.data_store.apply_patch @patch
+
+    assert_equal "Mike Uchman", Person.find( 'mike' ).name
+    assert_equal "Mike Uchman", Person.where( id: 'mike' ).first.name
+
+    GreyscaleRecord::Base.data_store.remove_patch
+
+    refute GreyscaleRecord::Base.data_store.send( :store ).patched?
+    
+    assert_empty Person.where( id: "mike" )
+
+    refute Person.all.map(&:id).include? "mike"
+
+  end
+
+  def test_can_apply_patch_in_block
+    GreyscaleRecord::Base.data_store.with_patch @patch do
+
+      assert_equal "Mike Uchman", Person.find( 'mike' ).name
+      assert_equal "Mike Uchman", Person.where( id: 'mike' ).first.name
+
+    end
+
+    refute GreyscaleRecord::Base.data_store.send( :store ).patched?
+    
+    assert_empty Person.where( id: "mike" )
+
+    refute Person.all.map(&:id).include? "mike"
+  end
+
+  def test_patch_application_is_thread_safe
+    Thread.new do
+      GreyscaleRecord::Base.data_store.apply_patch @patch
+
+      assert_equal "Mike Uchman", Person.find( 'mike' ).name
+      assert_equal "Mike Uchman", Person.where( id: 'mike' ).first.name
+
+      sleep 5
+    end
+    sleep 1
+
+    assert_empty Person.where( id: "mike" )
+
+    refute Person.all.map(&:id).include? "mike"
+  end
+
+end


### PR DESCRIPTION
Allows application of a `Hana::Patch`-like object to the store. This will allow you to temporarily inject changes into the local store without modifying the underlying data.

As an example:

```ruby
    patch = ::Hana::Patch.new [ { 'op' => 'add', 'path' => '/people/mike', 'value' => { id: "mike", name: "Mike Uchman" } } ]

    data_store.apply_patch patch

    Person.find( 'mike' ).name # => "Mike Uchman"
    Person.where( id: 'mike' ).first.name #=> "Mike Uchman"

    data_store.remove_patch

    Person.where( id: "mike" ) #=> []
```

Or, if you are doing something simple and can fir your code in a single block, you can do:

```ruby
    data_store.with_patch patch do

      Person.find( 'mike' ).name # => "Mike Uchman"
      Person.where( id: 'mike' ).first.name #=> "Mike Uchman"

    end

    Person.where( id: "mike" ) #=> []
```
